### PR TITLE
Investigate redis queue depth issue

### DIFF
--- a/scripts/redis-diagnostics.sh
+++ b/scripts/redis-diagnostics.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Quick Redis stream diagnostics for firehose
+set -euo pipefail
+
+REDIS_CLI=${REDIS_CLI:-redis-cli}
+STREAM=${STREAM:-firehose:events}
+GROUP=${GROUP:-firehose-processors}
+DLQ=${DLQ:-firehose:dead-letters}
+
+header() { echo -e "\n==== $1 ===="; }
+
+# Basic info
+header "Basic info"
+$REDIS_CLI PING || { echo "redis-cli cannot connect"; exit 1; }
+
+# Stream sizes
+header "Stream sizes"
+$REDIS_CLI XLEN "$STREAM" | awk '{print "XLEN "$0}'
+$REDIS_CLI XLEN "$DLQ" | awk '{print "DLQ XLEN "$0}'
+
+# Group info and XPENDING summary
+header "Group info"
+$REDIS_CLI XINFO GROUPS "$STREAM" || true
+
+header "XPENDING summary"
+$REDIS_CLI XPENDING "$STREAM" "$GROUP" || true
+
+header "Top consumers by pending"
+# Show per-consumer pending list, top 10
+mapfile -t CONSUMERS < <($REDIS_CLI XINFO CONSUMERS "$STREAM" "$GROUP" | awk '/name/{print $2}' || true)
+for c in "${CONSUMERS[@]}"; do
+  cnt=$($REDIS_CLI XPENDING "$STREAM" "$GROUP" - + 100 $c 2>/dev/null | wc -l | tr -d ' ')
+  echo "$cnt $c"
+done | sort -rn | head -10
+
+header "Oldest pending (10)"
+$REDIS_CLI XPENDING "$STREAM" "$GROUP" - + 10 || true
+
+header "Recent DLQ entries (5)"
+$REDIS_CLI XREVRANGE "$DLQ" + - COUNT 5 || true
+
+cat <<EOF
+
+Hints:
+- If XLEN >> XPENDING, producers are outpacing consumers but acks are happening.
+- If XPENDING grows continually, consumers are failing to ack; inspect logs for errors.
+- High per-consumer pending suggests a stuck consumer; consider restart or XCLAIM.
+- Many DLQ entries means poison messages; inspect /api/redis/dead-letters.
+EOF


### PR DESCRIPTION
Implement dead-letter queueing and switch Redis queue depth metrics to pending messages, along with new diagnostic tools, to better identify and resolve queue backups.

The previous queue depth metric (XLEN) did not distinguish between actively processed messages and truly unacknowledged backlog, making it difficult to diagnose Redis queue backups. This PR introduces dead-letter handling for poison messages, switches queue depth to measure actual pending items, and provides new diagnostics to quickly pinpoint the source of issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-93178476-e516-4c7d-a0e3-b35bfccb7312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93178476-e516-4c7d-a0e3-b35bfccb7312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

