### PR TITLE
Verify appview to PDS authentication and key setup

### DIFF
--- a/server/services/feed-generator-client.ts
+++ b/server/services/feed-generator-client.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { didResolver } from "./did-resolver";
 import { storage } from "../storage";
+import { appViewJWTService } from "./appview-jwt";
 import type { Post } from "@shared/schema";
 
 const skeletonPostSchema = z.object({
@@ -53,6 +54,14 @@ export class FeedGeneratorClient {
       if (options?.viewerAuthorization) {
         headers["Authorization"] = options.viewerAuthorization;
         console.log(`[FeedGenClient] Forwarded viewer Authorization header to feedgen`);
+      } else if (params.feedGeneratorDid) {
+        try {
+          const serviceToken = appViewJWTService.signFeedGeneratorToken(params.feedGeneratorDid);
+          headers["Authorization"] = `Bearer ${serviceToken}`;
+          console.log(`[FeedGenClient] Attached AppView service Authorization for ${params.feedGeneratorDid}`);
+        } catch (err) {
+          console.warn(`[FeedGenClient] Failed to attach AppView service token:`, err);
+        }
       }
 
       const response = await fetch(url.toString(), {


### PR DESCRIPTION
Wire AppView service-level JWT authentication into feed generator requests to enable secure communication when a viewer token is absent.

The previous implementation only forwarded viewer authorization. This change introduces an AppView-signed JWT (preferring ES256 with `appview-private.pem` and falling back to HS256) for feed generator calls when no viewer token is available, ensuring authenticated service-to-service communication.

---
<a href="https://cursor.com/background-agent?bcId=bc-3eb26d20-d5b1-4d3a-8dec-979e1c9aa6ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3eb26d20-d5b1-4d3a-8dec-979e1c9aa6ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

