### PR TITLE
Debug invalid server response and validation errors

### DIFF
--- a/server/services/xrpc-api.ts
+++ b/server/services/xrpc-api.ts
@@ -1094,7 +1094,7 @@ export class XRPCApi {
               $type: 'app.bsky.actor.defs#profileView',
               did: user.did,
               handle: user.handle,
-              displayName: user.displayName,
+              displayName: user.displayName || "",
               ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
               indexedAt: user.indexedAt.toISOString(),
               viewer: viewer,
@@ -1151,7 +1151,7 @@ export class XRPCApi {
               $type: 'app.bsky.actor.defs#profileView',
               did: user.did,
               handle: user.handle,
-              displayName: user.displayName,
+              displayName: user.displayName || "",
               ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
               indexedAt: user.indexedAt.toISOString(),
               viewer: viewer,
@@ -1177,7 +1177,7 @@ export class XRPCApi {
         actors: users.map((user) => ({
           did: user.did,
           handle: user.handle,
-          displayName: user.displayName,
+          displayName: user.displayName || "",
           ...(user.description && { description: user.description }),
           ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
         })),
@@ -1212,7 +1212,7 @@ export class XRPCApi {
             return {
               did: user.did,
               handle: user.handle,
-              displayName: user.displayName,
+              displayName: user.displayName || "",
               ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
               viewer: {
                 blocking: b.uri,
@@ -1252,7 +1252,7 @@ export class XRPCApi {
             return {
               did: user.did,
               handle: user.handle,
-              displayName: user.displayName,
+              displayName: user.displayName || "",
               ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
               viewer: {
                 muted: true,
@@ -1433,7 +1433,7 @@ export class XRPCApi {
         followers: followers.map((user) => ({
           did: user.did,
           handle: user.handle,
-          displayName: user.displayName,
+          displayName: user.displayName || "",
           ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
         })),
       });
@@ -1458,7 +1458,7 @@ export class XRPCApi {
         suggestions: suggestions.map((user) => ({
           did: user.did,
           handle: user.handle,
-          displayName: user.displayName,
+          displayName: user.displayName || "",
           ...(user.description && { description: user.description }),
           ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
         })),
@@ -2631,7 +2631,7 @@ export class XRPCApi {
           isRead: n.isRead,
           indexedAt: n.indexedAt.toISOString(),
           reason: n.reason,
-          reasonSubject,
+          reasonSubject: reasonSubject || "",
           ...(record && { record }),
           author: author
             ? {
@@ -2804,7 +2804,7 @@ export class XRPCApi {
               actor: {
                 did: user.did,
                 handle: user.handle,
-                displayName: user.displayName,
+                displayName: user.displayName || "",
                 ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
                 viewer,
               },
@@ -2859,7 +2859,7 @@ export class XRPCApi {
             return {
               did: user.did,
               handle: user.handle,
-              displayName: user.displayName,
+              displayName: user.displayName || "",
               ...(user.avatarUrl && { avatar: this.transformBlobToCdnUrl(user.avatarUrl, user.did, 'avatar') }),
               viewer,
               indexedAt: repost.indexedAt.toISOString(),


### PR DESCRIPTION
Ensure `displayName` and `reasonSubject` fields are always strings in XRPC API responses to prevent client-side validation errors.

The AT Protocol client library expects `displayName` and `reasonSubject` to be strings, but the database schema allows these fields to be null. This PR modifies the XRPC API endpoints to return an empty string (`""`) instead of `null` when these fields are not set, satisfying the client's validation requirements and resolving `XRPCInvalidResponseError` and `ValidationError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c09da2bf-baae-447f-9f01-9a75566bd394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c09da2bf-baae-447f-9f01-9a75566bd394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

