### PR TITLE
Handle duplicate post aggregation errors

### DIFF
--- a/server/services/event-processor.ts
+++ b/server/services/event-processor.ts
@@ -891,14 +891,21 @@ export class EventProcessor {
     await this.storage.createPost(post);
     
     // Create post aggregation record
-    await this.storage.createPostAggregation({
-      postUri: uri,
-      likeCount: 0,
-      repostCount: 0,
-      replyCount: 0,
-      bookmarkCount: 0,
-      quoteCount: 0,
-    });
+    try {
+      await this.storage.createPostAggregation({
+        postUri: uri,
+        likeCount: 0,
+        repostCount: 0,
+        replyCount: 0,
+        bookmarkCount: 0,
+        quoteCount: 0,
+      });
+    } catch (error: any) {
+      // Ignore duplicate key errors (23505) - aggregation already exists
+      if (error?.code !== '23505') {
+        throw error;
+      }
+    }
     
     // If this is a reply, increment the parent post's reply count and create thread context
     if (record.reply?.parent.uri) {


### PR DESCRIPTION
Catch duplicate key errors when creating post aggregations to prevent log spam from harmless duplicate events.

The event processor receives duplicate post events from the firehose (e.g., during reconnections or backfills). While `createPost` already handles duplicate key errors silently, the subsequent `createPostAggregation` call did not, leading to `post_aggregations_pkey` constraint violation errors flooding the logs. These errors are harmless as the aggregation record already exists, but they obscure real issues. This change aligns `createPostAggregation`'s error handling with `createPost`'s.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c727a55-5bb7-41fb-b01a-6d691fbbf728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c727a55-5bb7-41fb-b01a-6d691fbbf728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

