### PR TITLE
Suppress duplicate key error logs

### DIFF
--- a/server/services/event-processor.ts
+++ b/server/services/event-processor.ts
@@ -825,7 +825,13 @@ export class EventProcessor {
         default:
           smartConsole.log(`[EVENT_PROCESSOR] Unknown record type: ${recordType}`);
       }
-    } catch (error) {
+    } catch (error: any) {
+      // Handle duplicate key errors gracefully (common during firehose reconnections)
+      // Silently skip duplicates as they don't matter
+      if (error?.code === '23505') {
+        // Silently skip duplicates
+        return;
+      }
       smartConsole.error(`[EVENT_PROCESSOR] Error processing record ${uri}:`, error);
     }
   }


### PR DESCRIPTION
Suppress duplicate key error logs in `processRecord` to clean up logs from expected, non-critical errors.

The `processRecord` method was logging all errors, including PostgreSQL duplicate key violations (error code `23505`). These errors are common during firehose reconnections or when re-processing records and do not indicate a functional issue. This change aligns `processRecord` with `processCommit`, which already handles these errors silently, reducing log noise.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1840837-2ad9-4830-82ac-116efeac8b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1840837-2ad9-4830-82ac-116efeac8b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

