### PR TITLE
Changes from background agent bc-22c05adb-7911-4673-b997-a613a0f6dea5

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -85,6 +85,7 @@ export interface IStorage {
   // Follow operations
   createFollow(follow: InsertFollow): Promise<Follow>;
   deleteFollow(uri: string, userDid: string): Promise<void>;
+  getFollow(uri: string): Promise<Follow | undefined>;
   getFollows(followerDid: string, limit?: number): Promise<Follow[]>;
   getFollowers(followingDid: string, limit?: number): Promise<Follow[]>;
   isFollowing(followerDid: string, followingDid: string): Promise<boolean>;
@@ -1124,6 +1125,11 @@ export class DatabaseStorage implements IStorage {
     // Update Redis counter for dashboard metrics
     const { redisQueue } = await import("./services/redis-queue");
     await redisQueue.incrementRecordCount('follows', -1);
+  }
+
+  async getFollow(uri: string): Promise<Follow | undefined> {
+    const [result] = await this.db.select().from(follows).where(eq(follows.uri, uri));
+    return result;
   }
 
   async getFollows(followerDid: string, limit = 100): Promise<Follow[]> {


### PR DESCRIPTION
Add `getFollow` method to storage to resolve `TypeError` during follow record deletions.

---
<a href="https://cursor.com/background-agent?bcId=bc-22c05adb-7911-4673-b997-a613a0f6dea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22c05adb-7911-4673-b997-a613a0f6dea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

