### PR TITLE
Fix timeline data fetching errors by referencing atproto

### DIFF
--- a/server/services/hydration/video-uri-builder.ts
+++ b/server/services/hydration/video-uri-builder.ts
@@ -1,0 +1,47 @@
+import * as util from 'node:util';
+
+/**
+ * VideoUriBuilder - Builds video playlist and thumbnail URLs
+ * Following Bluesky's implementation pattern
+ */
+export class VideoUriBuilder {
+  private playlistUrlPattern: string;
+  private thumbnailUrlPattern: string;
+
+  constructor(opts?: {
+    playlistUrlPattern?: string;
+    thumbnailUrlPattern?: string;
+  }) {
+    // Default patterns based on typical video service URLs
+    // These should be configured based on your video service endpoint
+    const baseUrl = process.env.VIDEO_SERVICE_URL || 
+                    process.env.PUBLIC_URL ||
+                    (process.env.REPLIT_DEV_DOMAIN ? `https://${process.env.REPLIT_DEV_DOMAIN}` : '') ||
+                    (process.env.REPLIT_DOMAINS ? `https://${process.env.REPLIT_DOMAINS.split(',')[0]}` : '');
+    
+    this.playlistUrlPattern = opts?.playlistUrlPattern || `${baseUrl}/vid/%s/%s/playlist.m3u8`;
+    this.thumbnailUrlPattern = opts?.thumbnailUrlPattern || `${baseUrl}/vid/%s/%s/thumbnail.jpg`;
+  }
+
+  /**
+   * Generate HLS playlist URL for a video
+   */
+  playlist({ did, cid }: { did: string; cid: string }): string {
+    return util.format(
+      this.playlistUrlPattern,
+      encodeURIComponent(did),
+      encodeURIComponent(cid),
+    );
+  }
+
+  /**
+   * Generate thumbnail URL for a video
+   */
+  thumbnail({ did, cid }: { did: string; cid: string }): string {
+    return util.format(
+      this.thumbnailUrlPattern,
+      encodeURIComponent(did),
+      encodeURIComponent(cid),
+    );
+  }
+}


### PR DESCRIPTION
Add `VideoUriBuilder` and update `EmbedResolver` to correctly generate video embed URLs.

This fixes the `e.ValidationError: Output/feed/6/post/embed must have the property "playlist"` error by ensuring all video embeds in timeline responses include the required `playlist` field with a valid URL, aligning with the AT Protocol lexicon and Bluesky's implementation. Previously, the `playlist` field was explicitly set to `undefined`, causing validation failures on the client side.

---
<a href="https://cursor.com/background-agent?bcId=bc-57bd2178-9908-4133-9f0d-7a748000af6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57bd2178-9908-4133-9f0d-7a748000af6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

