### PR TITLE
Fix sanitizeObject reference error

### DIFF
--- a/server/services/event-processor.ts
+++ b/server/services/event-processor.ts
@@ -5,6 +5,7 @@ import { didResolver } from "./did-resolver";
 import { pdsDataFetcher } from "./pds-data-fetcher";
 import { smartConsole } from "./console-wrapper";
 import { logAggregator } from "./log-aggregator";
+import { sanitizeObject } from "../utils/sanitize";
 import type { InsertUser, InsertPost, InsertLike, InsertRepost, InsertFollow, InsertBlock, InsertList, InsertListItem, InsertFeedGenerator, InsertStarterPack, InsertLabelerService, InsertFeedItem, InsertQuote, InsertVerification } from "@shared/schema";
 import { CID } from 'multiformats/cid';
 import * as Digest from 'multiformats/hashes/digest';


### PR DESCRIPTION
Add missing import for `sanitizeObject` to resolve `ReferenceError` in event processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b58c309c-eb3e-4caf-83f6-3e20a5cb092b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b58c309c-eb3e-4caf-83f6-3e20a5cb092b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

