### PR TITLE
Fix constellation integration errors

### DIFF
--- a/microcosm-bridge/constellation-client/src/api-client.ts
+++ b/microcosm-bridge/constellation-client/src/api-client.ts
@@ -105,7 +105,20 @@ export class ConstellationAPIClient {
       }
 
       const text = await response.text();
-      const count = parseInt(text.trim(), 10);
+      let count: number;
+      
+      // Try to parse as JSON first (new API format)
+      try {
+        const json = JSON.parse(text);
+        if (typeof json === 'object' && 'total' in json) {
+          count = parseInt(String(json.total), 10);
+        } else {
+          throw new Error('JSON response missing total field');
+        }
+      } catch (jsonError) {
+        // Fall back to plain text number (old API format)
+        count = parseInt(text.trim(), 10);
+      }
 
       if (isNaN(count)) {
         throw new Error(`Invalid response from Constellation API: ${text}`);

--- a/server/services/constellation-integration.ts
+++ b/server/services/constellation-integration.ts
@@ -147,7 +147,20 @@ class ConstellationIntegration {
       }
 
       const text = await response.text();
-      const count = parseInt(text.trim(), 10);
+      let count: number;
+      
+      // Try to parse as JSON first (new API format)
+      try {
+        const json = JSON.parse(text);
+        if (typeof json === 'object' && 'total' in json) {
+          count = parseInt(String(json.total), 10);
+        } else {
+          throw new Error('JSON response missing total field');
+        }
+      } catch (jsonError) {
+        // Fall back to plain text number (old API format)
+        count = parseInt(text.trim(), 10);
+      }
       
       if (isNaN(count)) {
         throw new Error(`Invalid response: ${text}`);


### PR DESCRIPTION
Update Constellation API integration to correctly parse JSON responses for link counts.

The Constellation API changed its response format from plain text numbers (e.g., "0") to JSON objects (e.g., `{"total":0}`). This PR modifies `getLinksCount` to first attempt parsing the response as JSON and extract the `total` field, falling back to plain number parsing for backward compatibility. This resolves "Invalid response" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-8dbb59f3-627a-4b93-8b72-147351886e26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8dbb59f3-627a-4b93-8b72-147351886e26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

