### PR TITLE
Process firehose events and handle notifications

### DIFF
--- a/server/services/event-processor.ts
+++ b/server/services/event-processor.ts
@@ -1042,7 +1042,7 @@ export class EventProcessor {
             reasonSubject: uri,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
         }
       } catch (error) {
@@ -1073,7 +1073,7 @@ export class EventProcessor {
             reasonSubject: uri,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
           processedMentions.add(handle);
         }
@@ -1119,7 +1119,7 @@ export class EventProcessor {
             reasonSubject: uri,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
         }
       }
@@ -1187,7 +1187,7 @@ export class EventProcessor {
             reasonSubject: postUri,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
         } catch (error) {
           smartConsole.error(`[NOTIFICATION] Error creating like notification:`, error);
@@ -1265,7 +1265,7 @@ export class EventProcessor {
             reasonSubject: postUri,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
         } catch (error) {
           smartConsole.error(`[NOTIFICATION] Error creating repost notification:`, error);
@@ -1402,7 +1402,7 @@ export class EventProcessor {
             reasonSubject: undefined,
             cid: cid,
             isRead: false,
-            createdAt: new Date(record.createdAt),
+            createdAt: this.safeDate(record.createdAt),
           });
         } catch (error) {
           smartConsole.error(`[NOTIFICATION] Error creating follow notification:`, error);


### PR DESCRIPTION
Replace `new Date(record.createdAt)` with `this.safeDate(record.createdAt)` to fix "RangeError: Invalid time value" errors in notification creation.

The `createdAt` field from the Python firehose consumer can sometimes be in a format that `new Date()` cannot parse, leading to errors. Using `this.safeDate()` ensures that dates are handled gracefully, preventing notification failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-6250bd2f-a00b-459b-a577-999445318f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6250bd2f-a00b-459b-a577-999445318f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

