### PR TITLE
Debug database interaction errors

### DIFF
--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -84,6 +84,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      app:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import asyncio; import redis.asyncio as redis; asyncio.run(redis.from_url('redis://redis:6379').ping())\" || exit 1"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
+      app:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import redis; r = redis.from_url('redis://redis:6379'); r.ping()\" || exit 1"]
       interval: 30s

--- a/python-firehose/redis_consumer_worker.py
+++ b/python-firehose/redis_consumer_worker.py
@@ -45,17 +45,50 @@ class DatabasePool:
         self.pool: Optional[asyncpg.Pool] = None
         
     async def connect(self):
-        """Initialize database connection pool"""
+        """Initialize database connection pool with retry logic for schema initialization"""
         logger.info(f"Creating database pool with {self.pool_size} connections...")
-        self.pool = await asyncpg.create_pool(
-            self.database_url,
-            min_size=10,
-            max_size=self.pool_size,
-            command_timeout=60,
-            max_queries=50000,
-            max_inactive_connection_lifetime=300,
-        )
-        logger.info("Database pool created successfully")
+        
+        # Retry logic to wait for database schema to be created
+        max_retries = 30
+        retry_delay = 2  # seconds
+        
+        for attempt in range(max_retries):
+            try:
+                self.pool = await asyncpg.create_pool(
+                    self.database_url,
+                    min_size=10,
+                    max_size=self.pool_size,
+                    command_timeout=60,
+                    max_queries=50000,
+                    max_inactive_connection_lifetime=300,
+                )
+                
+                # Verify schema exists by checking for users table
+                async with self.pool.acquire() as conn:
+                    await conn.fetchval("SELECT COUNT(*) FROM users LIMIT 1")
+                
+                logger.info("Database pool created successfully and schema verified")
+                return
+                
+            except asyncpg.exceptions.UndefinedTableError:
+                logger.warning(f"Database schema not ready (attempt {attempt + 1}/{max_retries}). Waiting for schema creation...")
+                if self.pool:
+                    await self.pool.close()
+                    self.pool = None
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                else:
+                    logger.error("Database schema not created after maximum retries. Ensure the 'app' service has completed migrations.")
+                    raise
+            except Exception as e:
+                logger.error(f"Error creating database pool (attempt {attempt + 1}/{max_retries}): {e}")
+                if self.pool:
+                    await self.pool.close()
+                    self.pool = None
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                else:
+                    raise
         
     async def close(self):
         """Close database connection pool"""


### PR DESCRIPTION
Fix database 'relation does not exist' errors by ensuring Python workers wait for schema creation and adding connection retry logic.

The `python-worker` was encountering `UndefinedTableError` because it was attempting to interact with the database before the `app` service had completed its schema migrations. This PR resolves the race condition by updating Docker Compose dependencies to ensure `python-worker` waits for `app` to be healthy, and by adding robust retry logic to the database connection in the workers themselves.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4f92ba5-5a1d-4ca3-b3d9-e48386142b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4f92ba5-5a1d-4ca3-b3d9-e48386142b00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

