### PR TITLE
Fix datetime errors in post and like creation

### DIFF
--- a/python-firehose/label_service.py
+++ b/python-firehose/label_service.py
@@ -30,7 +30,7 @@ class LabelService:
     ) -> Dict[str, Any]:
         """Apply a label to a subject"""
         uri = f"at://{src}/app.bsky.labeler.label/{int(datetime.now(timezone.utc).timestamp() * 1000)}"
-        created_at = created_at or datetime.now(timezone.utc)
+        created_at = created_at or datetime.now(timezone.utc).replace(tzinfo=None)
         
         async with self.db_pool.acquire() as conn:
             try:

--- a/python-firehose/redis_consumer_worker.py
+++ b/python-firehose/redis_consumer_worker.py
@@ -146,14 +146,19 @@ class EventProcessor:
             return False
     
     def safe_date(self, value: Optional[str]) -> datetime:
-        """Parse date safely, returning current time if invalid"""
+        """Parse date safely, returning current time if invalid
+        
+        Returns naive datetime in UTC (without timezone info) to match PostgreSQL's
+        timestamp type which is 'timestamp without time zone'.
+        """
         if not value:
-            return datetime.now(timezone.utc)
+            return datetime.now(timezone.utc).replace(tzinfo=None)
         try:
             dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
-            return dt
+            # Convert to naive datetime in UTC for PostgreSQL compatibility
+            return dt.replace(tzinfo=None) if dt.tzinfo else dt
         except Exception:
-            return datetime.now(timezone.utc)
+            return datetime.now(timezone.utc).replace(tzinfo=None)
     
     async def process_post(
         self,


### PR DESCRIPTION
Convert timezone-aware datetimes to naive UTC datetimes to resolve PostgreSQL insertion errors.

PostgreSQL's `timestamp` type expects offset-naive datetimes, but Python workers were providing offset-aware datetimes. This mismatch caused "can't subtract offset-naive and offset-aware datetimes" errors during database insertions for posts, likes, and other records.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f544654-33a6-4416-946a-881ab99610af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f544654-33a6-4416-946a-881ab99610af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

