### PR TITLE
Debug invalid timeline response error

### DIFF
--- a/server/services/hydration/embed-resolver.ts
+++ b/server/services/hydration/embed-resolver.ts
@@ -95,9 +95,12 @@ export class EmbedResolver {
           resolved = {
             $type: 'app.bsky.embed.recordWithMedia#view',
             record: {
-              $type: 'app.bsky.embed.record#viewNotFound',  // Placeholder, will be hydrated
-              uri: recordUri,
-              notFound: true
+              $type: 'app.bsky.embed.record#view',
+              record: {
+                $type: 'app.bsky.embed.record#viewNotFound',  // Placeholder, will be hydrated
+                uri: recordUri,
+                notFound: true
+              }
             },
             media: this.resolveMediaEmbed(embed.media, post.authorDid)
           };
@@ -249,9 +252,11 @@ export class EmbedResolver {
             embed.record = childEmbeds.get(recordUri);
           }
         } else if (embed && embed.$type === 'app.bsky.embed.recordWithMedia#view') {
-          const recordUri = embed.record?.uri;
+          const recordUri = embed.record?.record?.uri;
           if (recordUri && childEmbeds.has(recordUri)) {
-            embed.record = childEmbeds.get(recordUri);
+            // For recordWithMedia, the record field is already wrapped in app.bsky.embed.record#view
+            // We just need to update the nested record property
+            embed.record.record = childEmbeds.get(recordUri);
           }
         }
       }


### PR DESCRIPTION
Corrects the structure of `app.bsky.embed.recordWithMedia#view` embeds to comply with AT Protocol, resolving client validation errors.

The client was receiving an `XRPCInvalidResponseError` with a `ValidationError` stating `Output/feed/0/post/embed/record must have the property "record"`. This was due to `recordWithMedia` embeds being incorrectly formed; the `record` field was directly assigned the `viewRecord` instead of being wrapped in an `app.bsky.embed.record#view` object as required by the AT Protocol specification. This PR adjusts both the initial placeholder creation and the hydration logic to ensure the correct nested structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-07303067-b183-44c8-818f-ac5767ce2d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07303067-b183-44c8-818f-ac5767ce2d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

