### PR TITLE
Fix image loading proxy error

### DIFF
--- a/server/services/hydration/embed-resolver.ts
+++ b/server/services/hydration/embed-resolver.ts
@@ -334,8 +334,8 @@ export class EmbedResolver {
     // Check for the string "undefined" which can happen with improper data extraction
     if (!cid || cid === 'undefined') return '';
     
-    // Always use Bluesky CDN for image hosting
-    return `https://cdn.bsky.app/img/${preset}/plain/${did}/${cid}@jpeg`;
+    // Use local image proxy to fetch from Bluesky CDN
+    return `/img/${preset}/plain/${did}/${cid}@jpeg`;
   }
   
   // Transform a plain CID string (as stored in database) to CDN URL
@@ -343,8 +343,8 @@ export class EmbedResolver {
     // Check for falsy values and the literal string "undefined"
     if (!cid || cid === 'undefined') return '';
     
-    // Always use Bluesky CDN for image hosting
-    return `https://cdn.bsky.app/img/${preset}/plain/${did}/${cid}@jpeg`;
+    // Use local image proxy to fetch from Bluesky CDN
+    return `/img/${preset}/plain/${did}/${cid}@jpeg`;
   }
 
   /**

--- a/server/services/pds-data-fetcher.ts
+++ b/server/services/pds-data-fetcher.ts
@@ -56,9 +56,9 @@ export class PDSDataFetcher {
   private transformBlobToCdnUrl(blobCid: string, userDid: string, format: 'avatar' | 'banner' = 'avatar'): string | undefined {
     if (!blobCid || blobCid === 'undefined') return undefined;
     
-    // Always use Bluesky CDN for image hosting
+    // Use local image proxy to fetch from Bluesky CDN
     const sizeStr = format === 'avatar' || format === 'banner' ? 'plain' : 'fullsize';
-    return `https://cdn.bsky.app/img/${format}/${sizeStr}/${userDid}/${blobCid}@jpeg`;
+    return `/img/${format}/${sizeStr}/${userDid}/${blobCid}@jpeg`;
   }
 
   constructor() {

--- a/server/services/xrpc-api.ts
+++ b/server/services/xrpc-api.ts
@@ -669,10 +669,10 @@ export class XRPCApi {
     // Check for falsy values and the literal string "undefined"
     if (!blobCid || blobCid === 'undefined') return undefined;
     
-    // Always use Bluesky CDN for image hosting
-    const cdnUrl = `https://cdn.bsky.app/img/${format}/plain/${userDid}/${blobCid}@jpeg`;
-    console.log(`[CDN_TRANSFORM] ${blobCid} -> ${cdnUrl}`);
-    return cdnUrl;
+    // Use local image proxy to fetch from Bluesky CDN
+    const proxyUrl = `/img/${format}/plain/${userDid}/${blobCid}@jpeg`;
+    console.log(`[CDN_TRANSFORM] ${blobCid} -> ${proxyUrl}`);
+    return proxyUrl;
   }
   
   // Transform a plain CID string (as stored in database) to CDN URL - same logic but clearer name


### PR DESCRIPTION
Proxy image requests through the appview to the Bluesky CDN to resolve "Failed to fetch" errors and ensure images load correctly for clients.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c5916de-b713-42bf-a5e2-886118cc3253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c5916de-b713-42bf-a5e2-886118cc3253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

