### PR TITLE
Fix profile display after car file import

### DIFF
--- a/CAR_IMPORT_FIX_SUMMARY.md
+++ b/CAR_IMPORT_FIX_SUMMARY.md
@@ -1,0 +1,85 @@
+# CAR File Import Profile Display Fix
+
+## Problem
+After importing a CAR file, several validation errors were occurring in the client:
+1. `embed/external/thumb must be a uri` - External link thumbnails with invalid/empty CIDs
+2. `embed/record/author/avatar must be a uri` - Avatar fields with empty strings or null values
+3. `displayName must be a string` - displayName fields that were null or non-string values
+
+These errors prevented profiles from showing:
+- Followers not displaying
+- Media tab not working
+- Likes not showing up
+
+## Root Cause
+When importing CAR files, the system was storing embed data and profile information without proper validation or normalization:
+
+1. **Embed Data**: External link thumbnails and image references with invalid/missing blob CIDs were stored as-is in the database
+2. **Profile Data**: Avatar and displayName fields were not being validated before serialization
+3. **Serialization**: The API was returning these invalid values directly to the client, causing AT Protocol validation errors
+
+## Solution
+
+### 1. Embed Normalization During Import (`event-processor.ts`)
+Added `normalizeEmbed()` function that:
+- Removes external embed thumbnails with invalid/missing CIDs
+- Filters out images with invalid blob references
+- Converts `recordWithMedia` to plain `record` embeds if media is invalid
+- Removes video thumbnails with invalid CIDs
+
+This normalization happens **before** storing posts in the database, ensuring only valid embed data is persisted.
+
+### 2. Avatar URI Validation (`embed-resolver.ts`)
+Updated embedded record author views to:
+- Only include `avatar` field when a valid URI can be generated
+- Ensure `displayName` is always a string (fallback to handle)
+- Use `'handle.invalid'` as fallback for missing handles (matches Bluesky's approach)
+
+### 3. Profile Field Validation (`xrpc-api.ts`, `views.ts`)
+Updated all profile serialization points to:
+- Ensure `displayName` is always a string (never null/undefined)
+- Fallback to `handle` when `displayName` is missing or invalid
+- Only include `avatar` field when it's a valid URI
+- Apply same fixes to reposts, pins, and other profile displays
+
+### 4. Feed Generator Validation (`xrpc-api.ts`)
+Updated feed generator serialization to:
+- Use `'Unnamed Feed'` as fallback for missing displayName
+
+## Files Modified
+1. `/workspace/server/services/event-processor.ts`
+   - Added `normalizeEmbed()` function
+   - Apply normalization during post creation
+
+2. `/workspace/server/services/hydration/embed-resolver.ts`
+   - Fixed author view construction for embedded records
+   - Ensured displayName is always a string
+   - Only include avatar when valid URI available
+
+3. `/workspace/server/services/xrpc-api.ts`
+   - Fixed displayName handling in post serialization (both enhanced and legacy paths)
+   - Fixed displayName handling in repost reasons
+   - Fixed displayName handling in feed generators
+
+4. `/workspace/server/services/views.ts`
+   - Fixed displayName handling in pin reasons
+   - Fixed displayName handling in repost reasons
+
+## Testing
+To verify the fix:
+1. Import a CAR file with posts containing external links/embeds
+2. Check that the profile page displays correctly
+3. Verify that followers, media tab, and likes all work
+4. Check browser console - should no longer see validation errors about URIs or displayName
+
+## AT Protocol Compliance
+These changes ensure full compliance with AT Protocol validation requirements:
+- `avatar` fields are proper URI strings (format: `/avatar/plain/{did}/{cid}@jpeg`) or omitted
+- `thumb` fields in embeds are proper URI strings or omitted
+- `displayName` fields are always strings (never null/undefined)
+- `handle` fields always have a fallback to `'handle.invalid'` when missing
+
+## References
+- Bluesky implementation: https://github.com/bluesky-social/atproto/tree/main/packages/bsky/src
+- ImageUriBuilder pattern: `/{preset}/plain/{did}/{cid}@{format}`
+- Standard fallback handle: `'handle.invalid'`

--- a/server/services/views.ts
+++ b/server/services/views.ts
@@ -109,13 +109,18 @@ export class Views {
       ? this.transformBlobToCdnUrl(authorProfile.avatarUrl, authorDid, 'avatar')
       : undefined;
 
+    // Ensure displayName is always a string
+    const displayName = (authorProfile.displayName && typeof authorProfile.displayName === 'string')
+      ? authorProfile.displayName
+      : authorProfile.handle;
+    
     return {
       $type: 'app.bsky.feed.defs#reasonPin',
       by: {
         $type: 'app.bsky.actor.defs#profileViewBasic',
         did: authorDid,
         handle: authorProfile.handle,
-        displayName: authorProfile.displayName ?? authorProfile.handle,
+        displayName: displayName,
         pronouns: authorProfile.pronouns,
         ...(avatarUrl && { avatar: avatarUrl }),
         associated: {
@@ -157,13 +162,18 @@ export class Views {
       ? this.transformBlobToCdnUrl(reposterProfile.avatarUrl, repost.userDid, 'avatar')
       : undefined;
 
+    // Ensure displayName is always a string
+    const displayName = (reposterProfile.displayName && typeof reposterProfile.displayName === 'string')
+      ? reposterProfile.displayName
+      : reposterProfile.handle;
+
     return {
       $type: 'app.bsky.feed.defs#reasonRepost',
       by: {
         $type: 'app.bsky.actor.defs#profileViewBasic',
         did: repost.userDid,
         handle: reposterProfile.handle,
-        displayName: reposterProfile.displayName ?? reposterProfile.handle,
+        displayName: displayName,
         pronouns: reposterProfile.pronouns,
         ...(avatarUrl && { avatar: avatarUrl }),
         associated: {

--- a/server/services/xrpc-api.ts
+++ b/server/services/xrpc-api.ts
@@ -819,6 +819,11 @@ export class XRPCApi {
         ? (avatarUrl.startsWith('http') ? avatarUrl : this.transformBlobToCdnUrl(avatarUrl, author.did, 'avatar', req))
         : undefined;
 
+      // Ensure displayName is always a string
+      const displayName = (author?.displayName && typeof author.displayName === 'string') 
+        ? author.displayName 
+        : authorHandle;
+      
       const postView: any = {
         $type: 'app.bsky.feed.defs#postView',
         uri: post.uri,
@@ -827,7 +832,7 @@ export class XRPCApi {
           $type: 'app.bsky.actor.defs#profileViewBasic',
           did: post.authorDid,
           handle: authorHandle,
-          displayName: author?.displayName ?? authorHandle,
+          displayName: displayName,
           pronouns: author?.pronouns,
           ...(avatarCdn && { avatar: avatarCdn }),
           viewer: actorViewerState || {},
@@ -1048,11 +1053,15 @@ export class XRPCApi {
         cid: post.cid,
         author: (() => {
           const avatarUrl = author?.avatarUrl ? this.transformBlobToCdnUrl(author.avatarUrl, author.did, 'avatar', req) : undefined;
+          // Ensure displayName is always a string
+          const displayName = (author?.displayName && typeof author.displayName === 'string') 
+            ? author.displayName 
+            : authorHandle;
           return {
             $type: 'app.bsky.actor.defs#profileViewBasic',
             did: post.authorDid,
             handle: authorHandle,
-            displayName: author?.displayName ?? authorHandle,
+            displayName: displayName,
             pronouns: author?.pronouns,
             ...(avatarUrl && { avatar: avatarUrl }),
             associated: {
@@ -1273,7 +1282,7 @@ export class XRPCApi {
                   $type: 'app.bsky.actor.defs#profileViewBasic',
                   did: reposter.did,
                   handle: reposter.handle,
-                  displayName: reposter.displayName,
+                  displayName: reposter.displayName || reposter.handle,
                   ...this.maybeAvatar(reposter.avatarUrl, reposter.did, req),
                 },
                 indexedAt: repost.indexedAt.toISOString(),
@@ -2384,7 +2393,7 @@ export class XRPCApi {
         cid: generator.cid,
         did: generator.did,
         creator: creatorView,
-        displayName: generator.displayName,
+        displayName: generator.displayName || 'Unnamed Feed',
         likeCount: generator.likeCount,
         indexedAt: generator.indexedAt.toISOString(),
         ...this.maybeAvatar(generator.avatarUrl, generator.creatorDid, req),
@@ -2432,7 +2441,7 @@ export class XRPCApi {
             cid: generator.cid,
             did: generator.did,
             creator: creatorView,
-            displayName: generator.displayName,
+            displayName: generator.displayName || 'Unnamed Feed',
             likeCount: generator.likeCount,
             indexedAt: generator.indexedAt.toISOString(),
           };
@@ -2490,7 +2499,7 @@ export class XRPCApi {
             cid: generator.cid,
             did: generator.did,
             creator: creatorView,
-            displayName: generator.displayName,
+            displayName: generator.displayName || 'Unnamed Feed',
             likeCount: generator.likeCount,
             indexedAt: generator.indexedAt.toISOString(),
           };
@@ -2541,7 +2550,7 @@ export class XRPCApi {
             cid: generator.cid,
             did: generator.did,
             creator: creatorView,
-            displayName: generator.displayName,
+            displayName: generator.displayName || 'Unnamed Feed',
             likeCount: generator.likeCount,
             indexedAt: generator.indexedAt.toISOString(),
           };
@@ -2634,7 +2643,7 @@ export class XRPCApi {
             cid: generator.cid,
             did: generator.did,
             creator: creatorView,
-            displayName: generator.displayName,
+            displayName: generator.displayName || 'Unnamed Feed',
             likeCount: generator.likeCount,
             indexedAt: generator.indexedAt.toISOString(),
           };


### PR DESCRIPTION
Normalize embed and profile data during CAR import and API serialization to resolve client-side AT Protocol validation errors.

This fixes issues where invalid/empty embed and profile data (thumbnails, avatars, display names) were causing client-side validation errors like "Output/... must be a uri" or "Output/... must be a string", preventing followers, media, and likes from displaying correctly after CAR file import.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fe75263-f426-4f7b-bfdd-daa2ce0a374d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fe75263-f426-4f7b-bfdd-daa2ce0a374d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

