### PR TITLE
Fix missing thread_gates relation

### DIFF
--- a/python-firehose/redis_consumer_worker.py
+++ b/python-firehose/redis_consumer_worker.py
@@ -774,7 +774,9 @@ class EventProcessor:
                 await conn.execute('DELETE FROM post_gates WHERE uri = $1', uri)
             
             elif collection == "app.bsky.feed.threadgate":
-                await conn.execute('DELETE FROM thread_gates WHERE uri = $1', uri)
+                # Thread gates are stored as metadata on posts, not in a separate table
+                # The hasThreadGate flag on posts will be updated when the post is re-indexed
+                logger.debug(f"Thread gate deletion requested for {uri} - handled via post metadata")
             
             elif collection == "app.bsky.graph.listblock":
                 await conn.execute('DELETE FROM list_blocks WHERE uri = $1', uri)

--- a/python-firehose/unified_worker.py
+++ b/python-firehose/unified_worker.py
@@ -1821,7 +1821,9 @@ class EventProcessor:
                 await conn.execute('DELETE FROM "postGates" WHERE uri = $1', uri)
             
             elif collection == "app.bsky.feed.threadgate":
-                await conn.execute('DELETE FROM "threadGates" WHERE uri = $1', uri)
+                # Thread gates are stored as metadata on posts, not in a separate table
+                # The hasThreadGate flag on posts will be updated when the post is re-indexed
+                logger.debug(f"Thread gate deletion requested for {uri} - handled via post metadata")
             
             elif collection == "app.bsky.graph.listblock":
                 await conn.execute('DELETE FROM "listBlocks" WHERE uri = $1', uri)

--- a/server/services/event-processor.ts
+++ b/server/services/event-processor.ts
@@ -1822,7 +1822,9 @@ export class EventProcessor {
         await this.storage.deletePostGate(uri);
         break;
       case "app.bsky.feed.threadgate":
-        await this.storage.deleteThreadGate(uri);
+        // Thread gates are stored as metadata on posts, not in a separate table
+        // The hasThreadGate flag on posts will be updated when the post is re-indexed
+        smartConsole.log(`[EVENT_PROCESSOR] Thread gate deletion requested for ${uri} - handled via post metadata`);
         break;
       case "app.bsky.graph.listblock":
         await this.storage.deleteListBlock(uri);


### PR DESCRIPTION
Remove erroneous database operations for `thread_gates` as the table does not exist and thread gates are handled as post metadata.

The database error `relation "thread_gates" does not exist` occurred because the code was attempting to delete from a non-existent table. Investigation revealed that thread gates are managed as metadata on posts (e.g., via a `hasThreadGate` flag) rather than in a dedicated `thread_gates` table, unlike `post_gates`. The fix removes these incorrect delete operations and adds logging, relying on post re-indexing to update the relevant metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f3c7387-8bf7-40f0-889c-fcc22fa16e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f3c7387-8bf7-40f0-889c-fcc22fa16e4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

