### PR TITLE
Fix constellation api rate limit error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ CONSTELLATION_ENABLED=false
 # Constellation settings (only used if CONSTELLATION_ENABLED=true)
 CONSTELLATION_URL=https://constellation.microcosm.blue
 CONSTELLATION_CACHE_TTL=60
+CONSTELLATION_TIMEOUT=10000
+# Rate limiting configuration to avoid 429 errors
+CONSTELLATION_REQUEST_DELAY=100
+CONSTELLATION_MAX_RETRIES=3
+CONSTELLATION_RETRY_DELAY=1000
 
 # Osprey Integration (federated labeling)
 OSPREY_ENABLED=false


### PR DESCRIPTION
Implement retry logic, rate limiting, and reduced parallelism for Constellation API requests to prevent 429 errors.

The Constellation API was returning 429 errors due to an excessive number of parallel requests. This PR introduces exponential backoff for 429 responses, enforces a minimum delay between requests, and changes `getPostStats` and `enrichAggregations` to process API calls sequentially rather than in parallel batches, significantly reducing the load on the Constellation API. Configuration options for rate limiting and retries are also added via environment variables.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b2928b9-0104-49b2-8cc6-698dd7ec384f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b2928b9-0104-49b2-8cc6-698dd7ec384f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

