### PR TITLE
Automate python backfill execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,21 @@ CONSTELLATION_RETRY_DELAY=1000
 # Osprey Integration (federated labeling)
 OSPREY_ENABLED=false
 
-# Other settings
-BACKFILL_DAYS=2
+# Backfill Configuration
+# Set BACKFILL_DAYS to automatically run historical backfill when the system starts
+# 0 = disabled (no backfill)
+# -1 = total backfill (entire available history)
+# >0 = backfill X days of history (e.g., 7 for last 7 days)
+BACKFILL_DAYS=0
+
+# Backfill Resource Throttling (optional - defaults shown below)
+# Uncomment and adjust based on your server's capacity
+# BACKFILL_BATCH_SIZE=5              # Events to process before delaying
+# BACKFILL_BATCH_DELAY_MS=2000       # Milliseconds to wait between batches
+# BACKFILL_MAX_CONCURRENT=2          # Maximum concurrent processing operations
+# BACKFILL_MAX_MEMORY_MB=512         # Pause if memory exceeds this limit
+# BACKFILL_USE_IDLE=true             # Use idle processing time
+# BACKFILL_DB_POOL_SIZE=2            # Database connection pool size for backfill
+
+# Data Retention
 DATA_RETENTION_DAYS=0

--- a/QUICKSTART-BACKFILL.md
+++ b/QUICKSTART-BACKFILL.md
@@ -1,0 +1,208 @@
+# Quick Start: Automatic Python Backfill
+
+This guide shows you how to enable automatic historical data backfill for your AT Protocol AppView.
+
+## What is Backfill?
+
+Backfill retrieves historical posts, likes, follows, and other events from the AT Protocol network and stores them in your database. This is useful when:
+- Setting up a new AppView instance
+- You want to populate your database with historical data
+- Users expect to see past posts in their feeds
+
+## How to Enable Backfill
+
+The Python backfill service runs automatically when you set the `BACKFILL_DAYS` environment variable.
+
+### Option 1: Using Environment Variables (Recommended)
+
+```bash
+# Set the backfill duration (pick one):
+export BACKFILL_DAYS=7      # Backfill last 7 days
+export BACKFILL_DAYS=30     # Backfill last 30 days
+export BACKFILL_DAYS=-1     # Backfill ALL available history
+
+# Optional: Configure backfill performance (defaults are conservative)
+export BACKFILL_BATCH_SIZE=5              # Events per batch
+export BACKFILL_BATCH_DELAY_MS=2000       # Delay between batches (ms)
+export BACKFILL_MAX_MEMORY_MB=512         # Memory limit
+
+# Start your services
+docker-compose up -d
+```
+
+### Option 2: Using .env File
+
+1. Copy `.env.example` to `.env` if you haven't already:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edit `.env` and set `BACKFILL_DAYS`:
+   ```bash
+   # In .env file:
+   BACKFILL_DAYS=7
+   ```
+
+3. Start your services:
+   ```bash
+   docker-compose up -d
+   ```
+
+## Backfill Configuration Options
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BACKFILL_DAYS` | `0` | `0`=disabled, `-1`=all history, `>0`=specific days |
+| `BACKFILL_BATCH_SIZE` | `5` | Events to process before pausing |
+| `BACKFILL_BATCH_DELAY_MS` | `2000` | Milliseconds to wait between batches |
+| `BACKFILL_MAX_CONCURRENT` | `2` | Max concurrent processing operations |
+| `BACKFILL_MAX_MEMORY_MB` | `512` | Pause if memory exceeds this limit |
+| `BACKFILL_USE_IDLE` | `true` | Use idle CPU time for processing |
+| `BACKFILL_DB_POOL_SIZE` | `2` | Database connection pool size |
+
+## Performance Profiles
+
+### Conservative (Default) - Background Task
+**~2.5 events/sec, ~9,000 events/hour**
+
+Best for: Running backfill alongside normal operations
+```bash
+export BACKFILL_DAYS=7
+export BACKFILL_BATCH_SIZE=5
+export BACKFILL_BATCH_DELAY_MS=2000
+export BACKFILL_MAX_MEMORY_MB=512
+```
+
+### Moderate - Balanced Speed
+**~20 events/sec, ~72,000 events/hour**
+
+Best for: Faster backfill with moderate resource usage
+```bash
+export BACKFILL_DAYS=30
+export BACKFILL_BATCH_SIZE=20
+export BACKFILL_BATCH_DELAY_MS=1000
+export BACKFILL_MAX_CONCURRENT=5
+export BACKFILL_MAX_MEMORY_MB=1024
+```
+
+### Aggressive - Maximum Speed
+**~100 events/sec, ~360,000 events/hour**
+
+Best for: Dedicated backfill on high-memory servers
+```bash
+export BACKFILL_DAYS=-1
+export BACKFILL_BATCH_SIZE=50
+export BACKFILL_BATCH_DELAY_MS=500
+export BACKFILL_MAX_CONCURRENT=10
+export BACKFILL_MAX_MEMORY_MB=2048
+```
+
+## Monitoring Backfill Progress
+
+### View Real-Time Logs
+```bash
+docker-compose logs -f python-backfill-worker
+```
+
+You'll see output like:
+```
+[BACKFILL] Starting 7-day historical backfill...
+[BACKFILL] Progress: 10000 received, 9500 processed, 500 skipped (250 evt/s)
+[BACKFILL] Memory: 245MB / 512MB limit
+```
+
+### Check Progress in Database
+```bash
+docker-compose exec db psql -U postgres -d atproto -c \
+  "SELECT * FROM firehose_cursor WHERE service = 'backfill';"
+```
+
+### Monitor with Docker
+```bash
+# Check if backfill worker is running
+docker-compose ps python-backfill-worker
+
+# View resource usage
+docker stats python-backfill-worker
+```
+
+## How It Works
+
+1. **Automatic Startup**: When `BACKFILL_DAYS` is set to a non-zero value, the `python-backfill-worker` service automatically starts
+2. **Background Processing**: The worker connects to the AT Protocol firehose and processes historical events
+3. **Progress Tracking**: Progress is saved to the database every 1000 events
+4. **Resume Capability**: If interrupted, backfill automatically resumes from the last saved position
+5. **Automatic Completion**: Once all historical data is processed, the backfill worker continues as a normal firehose worker
+
+## Disabling Backfill
+
+To disable backfill:
+
+```bash
+export BACKFILL_DAYS=0
+docker-compose up -d
+```
+
+Or remove/comment out the line in your `.env` file.
+
+## Troubleshooting
+
+### Backfill Not Starting
+
+Check logs:
+```bash
+docker-compose logs python-backfill-worker
+```
+
+Common issues:
+- `BACKFILL_DAYS=0` (backfill is disabled)
+- Database schema not initialized (wait for `app` service to complete migrations)
+- Memory or resource constraints
+
+### Slow Backfill Performance
+
+Try increasing these settings:
+```bash
+export BACKFILL_BATCH_SIZE=20
+export BACKFILL_BATCH_DELAY_MS=1000
+export BACKFILL_MAX_CONCURRENT=5
+export BACKFILL_MAX_MEMORY_MB=1024
+```
+
+### High Memory Usage
+
+The backfill automatically pauses when memory exceeds `BACKFILL_MAX_MEMORY_MB`. You can:
+- Increase the limit: `export BACKFILL_MAX_MEMORY_MB=1024`
+- Or reduce batch size: `export BACKFILL_BATCH_SIZE=3`
+
+### Database Connection Issues
+
+Ensure the app service has completed database migrations:
+```bash
+docker-compose logs app | grep migration
+```
+
+## Additional Documentation
+
+For detailed technical information, see:
+- [Python Backfill Service Documentation](python-firehose/README.backfill.md)
+- [Backfill Configuration Example](.env.backfill.example)
+
+## Example: Complete Setup
+
+```bash
+# 1. Set environment variables
+export BACKFILL_DAYS=7
+export BACKFILL_BATCH_SIZE=20
+export BACKFILL_BATCH_DELAY_MS=1000
+
+# 2. Start services
+docker-compose up -d
+
+# 3. Monitor progress
+docker-compose logs -f python-backfill-worker
+
+# 4. Check when complete (look for "Backfill completed" message)
+```
+
+That's it! Your AppView will now automatically backfill historical data whenever `BACKFILL_DAYS` is set.

--- a/README.md
+++ b/README.md
@@ -251,8 +251,9 @@ docker exec -it publicappview-app-1 sh
 - `APPVIEW_DID`: DID for this AppView instance (default: `did:web:appview.local`)
 - `PORT`: Server port (default: `5000`)
 - `NODE_ENV`: Environment mode (`development` or `production`)
-- `BACKFILL_DAYS`: Historical backfill in days (0=disabled, >0=backfill X days, default: `0`)
-  - See [BACKFILL_OPTIMIZATION.md](./BACKFILL_OPTIMIZATION.md) for resource throttling configuration
+- `BACKFILL_DAYS`: Historical backfill in days (0=disabled, -1=all history, >0=backfill X days, default: `0`)
+  - **NEW**: Python backfill now runs automatically when enabled! See [QUICKSTART-BACKFILL.md](./QUICKSTART-BACKFILL.md)
+  - Advanced configuration: [.env.backfill.example](./.env.backfill.example) and [Python Backfill Docs](./python-firehose/README.backfill.md)
 - `DATA_RETENTION_DAYS`: Auto-prune old data (0=keep forever, >0=prune after X days, default: `0`)
 - `DB_POOL_SIZE`: Database connection pool size (default: `32`)
 - `MAX_CONCURRENT_OPS`: Max concurrent event processing (default: `80`)

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -101,6 +101,47 @@ services:
         reservations:
           memory: 1G
 
+  # Python Unified Worker with Backfill Support
+  # Connects directly to firehose and processes to PostgreSQL with optional historical backfill
+  # Set BACKFILL_DAYS environment variable to enable: 0=disabled, -1=all history, >0=specific days
+  python-backfill-worker:
+    build:
+      context: ./python-firehose
+      dockerfile: Dockerfile.unified
+    environment:
+      - RELAY_URL=${RELAY_URL:-wss://bsky.network}
+      - DATABASE_URL=postgresql://postgres:password@db:5432/atproto
+      - DB_POOL_SIZE=20
+      - LOG_LEVEL=INFO
+      # Backfill configuration - Set BACKFILL_DAYS to enable automatic backfill
+      - BACKFILL_DAYS=${BACKFILL_DAYS:-0}
+      - BACKFILL_BATCH_SIZE=${BACKFILL_BATCH_SIZE:-5}
+      - BACKFILL_BATCH_DELAY_MS=${BACKFILL_BATCH_DELAY_MS:-2000}
+      - BACKFILL_MAX_CONCURRENT=${BACKFILL_MAX_CONCURRENT:-2}
+      - BACKFILL_MAX_MEMORY_MB=${BACKFILL_MAX_MEMORY_MB:-512}
+      - BACKFILL_USE_IDLE=${BACKFILL_USE_IDLE:-true}
+      - BACKFILL_DB_POOL_SIZE=${BACKFILL_DB_POOL_SIZE:-2}
+      # Worker ID (backfill only runs on worker 0)
+      - WORKER_ID=0
+    depends_on:
+      db:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import asyncpg; import asyncio; asyncio.run(asyncpg.connect('postgresql://postgres:password@db:5432/atproto', timeout=5).close())\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 40s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 1G
+
   # Frontend/API server - Lightweight since it's not processing firehose
   app:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,47 @@ services:
         reservations:
           memory: 1G
 
+  # Python Unified Worker with Backfill Support
+  # Connects directly to firehose and processes to PostgreSQL with optional historical backfill
+  # Set BACKFILL_DAYS environment variable to enable: 0=disabled, -1=all history, >0=specific days
+  python-backfill-worker:
+    build:
+      context: ./python-firehose
+      dockerfile: Dockerfile.unified
+    environment:
+      - RELAY_URL=${RELAY_URL:-wss://bsky.network}
+      - DATABASE_URL=postgresql://postgres:password@db:5432/atproto
+      - DB_POOL_SIZE=20
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      # Backfill configuration - Set BACKFILL_DAYS to enable automatic backfill
+      - BACKFILL_DAYS=${BACKFILL_DAYS:-0}
+      - BACKFILL_BATCH_SIZE=${BACKFILL_BATCH_SIZE:-5}
+      - BACKFILL_BATCH_DELAY_MS=${BACKFILL_BATCH_DELAY_MS:-2000}
+      - BACKFILL_MAX_CONCURRENT=${BACKFILL_MAX_CONCURRENT:-2}
+      - BACKFILL_MAX_MEMORY_MB=${BACKFILL_MAX_MEMORY_MB:-512}
+      - BACKFILL_USE_IDLE=${BACKFILL_USE_IDLE:-true}
+      - BACKFILL_DB_POOL_SIZE=${BACKFILL_DB_POOL_SIZE:-2}
+      # Worker ID (backfill only runs on worker 0)
+      - WORKER_ID=0
+    depends_on:
+      db:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import asyncpg; import asyncio; asyncio.run(asyncpg.connect('postgresql://postgres:password@db:5432/atproto', timeout=5).close())\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      start_period: 40s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 1G
+
   db:
     image: postgres:14
     # To any AI agents reading this, the resource settings here are correct. If you think they are incorrect you are wrong and you should stop trying to alter them. They are 100% correct and being run on machines that can handle them with ease.

--- a/python-firehose/README.backfill.md
+++ b/python-firehose/README.backfill.md
@@ -43,7 +43,50 @@ All configuration is done through environment variables:
 
 ## Usage
 
-### With Unified Worker
+### Quick Start with Docker Compose (Recommended)
+
+The backfill service is now **automatically integrated** into the docker-compose setup. To enable backfill:
+
+1. Set `BACKFILL_DAYS` in your environment:
+   ```bash
+   export BACKFILL_DAYS=7  # Backfill last 7 days
+   # OR for all history:
+   export BACKFILL_DAYS=-1
+   ```
+
+2. Start or restart your services:
+   ```bash
+   docker-compose up -d
+   ```
+
+The `python-backfill-worker` service will automatically:
+- Start when `BACKFILL_DAYS` is set to a non-zero value
+- Begin processing historical data in the background
+- Continue running until all historical data is processed
+- Save progress periodically for resume capability
+
+**Example: Backfill last 30 days with moderate speed**
+```bash
+export BACKFILL_DAYS=30
+export BACKFILL_BATCH_SIZE=20
+export BACKFILL_BATCH_DELAY_MS=1000
+export BACKFILL_MAX_MEMORY_MB=1024
+docker-compose up -d
+```
+
+To check backfill progress:
+```bash
+# View backfill worker logs
+docker-compose logs -f python-backfill-worker
+
+# Check progress in database
+docker-compose exec db psql -U postgres -d atproto -c \
+  "SELECT * FROM firehose_cursor WHERE service = 'backfill';"
+```
+
+### Manual Execution
+
+#### With Unified Worker
 
 The backfill service automatically starts when:
 1. `BACKFILL_DAYS` is set to a non-zero value
@@ -63,7 +106,7 @@ BACKFILL_MAX_MEMORY_MB=1024 \
 python unified_worker.py
 ```
 
-### Standalone Mode
+#### Standalone Mode
 
 You can also run the backfill service independently:
 


### PR DESCRIPTION
Add automatic Python backfill to Docker Compose setup, enabling it via the `BACKFILL_DAYS` environment variable.

The existing Docker Compose configuration used `redis_consumer_worker.py`, which lacked backfill support. This PR integrates the `unified_worker.py` with backfill capabilities into the Docker Compose setup, allowing it to run automatically when configured, and provides comprehensive documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9924f3a-c949-46e2-a69e-387dedfa7e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9924f3a-c949-46e2-a69e-387dedfa7e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

