### PR TITLE
Fix python indentation error in worker

### DIFF
--- a/python-firehose/unified_worker.py
+++ b/python-firehose/unified_worker.py
@@ -606,12 +606,12 @@ class EventProcessor:
                     # Create user with fallback handle - will be updated when profile is fetched
                     # This keeps the DB operation fast
                     try:
-            await conn.execute(
-                """
-                INSERT INTO users (did, handle, created_at)
-                VALUES ($1, $2, NOW())
-                ON CONFLICT (did) DO NOTHING
-                """,
+                        await conn.execute(
+                            """
+                            INSERT INTO users (did, handle, created_at)
+                            VALUES ($1, $2, NOW())
+                            ON CONFLICT (did) DO NOTHING
+                            """,
                             did,
                             INVALID_HANDLE
                         )


### PR DESCRIPTION
Fix indentation error in `unified_worker.py` to prevent worker crashes.

The `await conn.execute` statement was not properly indented within its `try` block, leading to an `IndentationError` that caused the `python-backfill-worker` to exit and restart repeatedly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b915071-3817-4a2e-a021-5c721492159e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b915071-3817-4a2e-a021-5c721492159e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

