### PR TITLE
Fix getTimeline followList map error

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1686,7 +1686,7 @@ export class DatabaseStorage implements IStorage {
 
   async getTimeline(userDid: string, limit = 50, cursor?: string): Promise<Post[]> {
     const followList = await this.getFollows(userDid);
-    const followingDids = followList.map(f => f.followingDid);
+    const followingDids = followList.follows.map(f => f.followingDid);
     
     console.log(`[STORAGE_DEBUG] getTimeline for ${userDid}: ${followingDids.length} follows`);
     


### PR DESCRIPTION
Fix `TypeError: followList.map is not a function` in `getTimeline`.

The `getTimeline` method was attempting to call `.map()` directly on the object returned by `getFollows`, which has a structure `{ follows: Follow[], cursor?: string }`. This PR corrects the code to access the `follows` array property before calling `.map()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-deb5d226-f0f4-4990-a14d-ffc6e5ec2b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-deb5d226-f0f4-4990-a14d-ffc6e5ec2b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

