### PR TITLE
Fix sql syntax errors in data loading

### DIFF
--- a/server/services/hydration/embed-resolver.ts
+++ b/server/services/hydration/embed-resolver.ts
@@ -61,10 +61,12 @@ export class EmbedResolver {
       postsData = loadedPosts.filter(Boolean);
     } else {
       // Fallback to direct database query
-      postsData = await db
-        .select()
-        .from(posts)
-        .where(inArray(posts.uri, uncachedUris));
+      postsData = uncachedUris.length > 0 
+        ? await db
+            .select()
+            .from(posts)
+            .where(inArray(posts.uri, uncachedUris))
+        : [];
     }
 
     const result = new Map<string, ResolvedEmbed | null>();


### PR DESCRIPTION
Add empty array checks before using `inArray` in Drizzle ORM queries to prevent SQL syntax errors.

The "syntax error at or near 'in'" occurred because `inArray` generated invalid SQL (`WHERE column IN ()`) when passed an empty array. This PR adds checks to return early or conditionally build queries when input arrays are empty, avoiding the invalid SQL.

---
<a href="https://cursor.com/background-agent?bcId=bc-03730f26-63c3-4e58-b011-187f3167311d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03730f26-63c3-4e58-b011-187f3167311d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

