### PR TITLE
Fix sql syntax errors in data loading

### DIFF
--- a/server/services/hydration/dataloader.ts
+++ b/server/services/hydration/dataloader.ts
@@ -213,8 +213,8 @@ export class HydrationDataLoader {
           : [];
 
         // Also fetch likes, reposts, bookmarks for viewer
-        const postUris = [...new Set(queries.map(q => q.uri))];
-        const viewerDids = [...new Set(queries.map(q => q.viewerDid))];
+        const postUris = [...new Set(queries.map(q => q.uri).filter(Boolean))];
+        const viewerDids = [...new Set(queries.map(q => q.viewerDid).filter(Boolean))];
 
         const [likesResult, repostsResult, bookmarksResult] = await Promise.all([
           postUris.length > 0 && viewerDids.length > 0 
@@ -286,8 +286,8 @@ export class HydrationDataLoader {
 
         if (queries.length === 0) return [];
 
-        const actorDids = [...new Set(queries.map(q => q.actorDid))];
-        const viewerDids = [...new Set(queries.map(q => q.viewerDid))];
+        const actorDids = [...new Set(queries.map(q => q.actorDid).filter(Boolean))];
+        const viewerDids = [...new Set(queries.map(q => q.viewerDid).filter(Boolean))];
 
         // Fetch all relationship data in parallel
         const [followsResult, blocksResult, mutesResult] = await Promise.all([


### PR DESCRIPTION
Filter out undefined/empty values in DataLoader queries to prevent SQL syntax errors.

The `split(':')` operation on malformed keys could result in `undefined` or empty string values being passed to Drizzle's `inArray()` function, which then generated invalid SQL (e.g., `WHERE column IN (..., undefined, ...)`). Adding `.filter(Boolean)` ensures only valid values are used.

---
<a href="https://cursor.com/background-agent?bcId=bc-02d5f21e-9b4c-48f9-92f3-819f00635f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02d5f21e-9b4c-48f9-92f3-819f00635f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

