### PR TITLE
Fix label propagator error in post hydration

### DIFF
--- a/server/services/hydration/dataloader-hydrator.ts
+++ b/server/services/hydration/dataloader-hydrator.ts
@@ -187,10 +187,9 @@ export class DataLoaderHydrator {
       );
 
       // Propagate labels if needed
-      const propagatedLabels = await this.labelPropagator.propagate(
-        labelMap,
-        postMap,
-        actorMap
+      const propagatedLabels = await this.labelPropagator.propagateActorLabels(
+        Array.from(actorDids),
+        Array.from(allPostUris)
       );
 
       stats.queryTime = performance.now() - queryStart;


### PR DESCRIPTION
Fix `TypeError: this.labelPropagator.propagate is not a function` by calling the correct `propagateActorLabels` method.

The `DataLoaderHydrator` was attempting to call a non-existent `propagate()` method on `this.labelPropagator`. This change updates the call to `propagateActorLabels()` with the correct parameters, aligning it with how other hydrators use the `LabelPropagator` service.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd6a29ea-2c8e-45f9-b293-18fdd0a998b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd6a29ea-2c8e-45f9-b293-18fdd0a998b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

