### PR TITLE
Fix undefined actorDids in data hydration

### DIFF
--- a/server/services/hydration/dataloader-hydrator.ts
+++ b/server/services/hydration/dataloader-hydrator.ts
@@ -188,7 +188,7 @@ export class DataLoaderHydrator {
 
       // Propagate labels if needed
       const propagatedLabels = await this.labelPropagator.propagateActorLabels(
-        Array.from(actorDids),
+        Array.from(authorDids),
         Array.from(allPostUris)
       );
 


### PR DESCRIPTION
Fix `ReferenceError: actorDids is not defined` by correcting a variable name mismatch in `DataLoaderHydrator.hydratePosts`.

The `authorDids` variable was declared but then incorrectly referenced as `actorDids`, leading to the `ReferenceError` in timeline, author feed, and likes endpoints.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ee1724f-00fe-44d8-a0ec-2487dd7de3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ee1724f-00fe-44d8-a0ec-2487dd7de3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

