### PR TITLE
Debug app timeline and hydrator errors

### DIFF
--- a/server/services/hydration.ts
+++ b/server/services/hydration.ts
@@ -78,8 +78,9 @@ export class Hydrator {
     for (const did of actorDids) {
       const state: ProfileViewerState = {};
       
-      if (blocking.some(b => b.blockedDid === did)) {
-        state.blocking = true;
+      const blockRecord = blocking.find(b => b.blockedDid === did);
+      if (blockRecord) {
+        state.blocking = blockRecord.uri;
       }
       
       if (blockedBy.some(b => b.blockerDid === did)) {

--- a/server/services/xrpc-api.ts
+++ b/server/services/xrpc-api.ts
@@ -1686,9 +1686,9 @@ export class XRPCApi {
             };
           }
           viewer.blockedBy = viewerState.blockedBy;
-          viewer.blocking = viewerState.blocking || undefined;
-          viewer.following = viewerState.following || undefined;
-          viewer.followedBy = viewerState.followedBy || undefined;
+          if (viewerState.blocking) viewer.blocking = viewerState.blocking;
+          if (viewerState.following) viewer.following = viewerState.following;
+          if (viewerState.followedBy) viewer.followedBy = viewerState.followedBy;
         }
 
         const profileView: any = {
@@ -1885,13 +1885,13 @@ export class XRPCApi {
             const viewerState = viewerDid
               ? relationships.get(f.followingDid)
               : null;
-            const viewer = {
+            const viewer: any = {
               muted: viewerState ? !!viewerState.muting : false,
               blockedBy: viewerState?.blockedBy || false,
-              blocking: viewerState?.blocking || undefined,
-              following: viewerState?.following || undefined,
-              followedBy: viewerState?.followedBy || undefined,
             };
+            if (viewerState?.blocking) viewer.blocking = viewerState.blocking;
+            if (viewerState?.following) viewer.following = viewerState.following;
+            if (viewerState?.followedBy) viewer.followedBy = viewerState.followedBy;
 
             return {
               $type: 'app.bsky.actor.defs#profileView',
@@ -1960,13 +1960,13 @@ export class XRPCApi {
             const viewerState = viewerDid
               ? relationships.get(f.followerDid)
               : null;
-            const viewer = {
+            const viewer: any = {
               muted: viewerState ? !!viewerState.muting : false,
               blockedBy: viewerState?.blockedBy || false,
-              blocking: viewerState?.blocking || undefined,
-              following: viewerState?.following || undefined,
-              followedBy: viewerState?.followedBy || undefined,
             };
+            if (viewerState?.blocking) viewer.blocking = viewerState.blocking;
+            if (viewerState?.following) viewer.following = viewerState.following;
+            if (viewerState?.followedBy) viewer.followedBy = viewerState.followedBy;
 
             return {
               $type: 'app.bsky.actor.defs#profileView',
@@ -3880,13 +3880,13 @@ export class XRPCApi {
             const viewerState = viewerDid
               ? relationships.get(like.userDid)
               : null;
-            const viewer = {
+            const viewer: any = {
               muted: viewerState ? !!viewerState.muting : false,
               blockedBy: viewerState?.blockedBy || false,
-              blocking: viewerState?.blocking || undefined,
-              following: viewerState?.following || undefined,
-              followedBy: viewerState?.followedBy || undefined,
             };
+            if (viewerState?.blocking) viewer.blocking = viewerState.blocking;
+            if (viewerState?.following) viewer.following = viewerState.following;
+            if (viewerState?.followedBy) viewer.followedBy = viewerState.followedBy;
 
             return {
               actor: {
@@ -3936,13 +3936,13 @@ export class XRPCApi {
             const viewerState = viewerDid
               ? relationships.get(repost.userDid)
               : null;
-            const viewer = {
+            const viewer: any = {
               muted: viewerState ? !!viewerState.muting : false,
               blockedBy: viewerState?.blockedBy || false,
-              blocking: viewerState?.blocking || undefined,
-              following: viewerState?.following || undefined,
-              followedBy: viewerState?.followedBy || undefined,
             };
+            if (viewerState?.blocking) viewer.blocking = viewerState.blocking;
+            if (viewerState?.following) viewer.following = viewerState.following;
+            if (viewerState?.followedBy) viewer.followedBy = viewerState.followedBy;
 
             return {
               did: user.did,

--- a/server/types/feed.ts
+++ b/server/types/feed.ts
@@ -58,15 +58,15 @@ export interface ProfileViewerState {
     purpose: string;
   };
   blockedBy?: boolean;
-  blocking?: string; // URI, not boolean
+  blocking?: string | null; // URI string when blocked, null otherwise (not boolean)
   blockingByList?: {
     $type: 'app.bsky.graph.defs#listViewBasic';
     uri: string;
     name: string;
     purpose: string;
   };
-  following?: string; // URI, not boolean
-  followedBy?: string; // URI, not boolean
+  following?: string | null; // URI string when following, null otherwise (not boolean)
+  followedBy?: string | null; // URI string when followed, null otherwise (not boolean)
   knownFollowers?: {
     $type: 'app.bsky.actor.defs#knownFollowers';
     count: number;


### PR DESCRIPTION
Fix `viewer.blocking`, `following`, and `followedBy` fields to conform to AT Protocol specification.

The server was returning incorrect data types (booleans or undefined) for viewer relationship fields (`blocking`, `following`, `followedBy`), which violated the AT Protocol specification requiring string URIs or omission. This caused `XRPCInvalidResponseError` and `ValidationError` in the appview client, preventing posts from displaying. This PR updates the dataloader and XRPC API to correctly return string URIs or omit the fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7cb95f5-4ac2-455f-8ae2-5194f7918501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7cb95f5-4ac2-455f-8ae2-5194f7918501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

