### PR TITLE
Debug invalid post hydration errors

### DIFF
--- a/server/services/hydration/dataloader.ts
+++ b/server/services/hydration/dataloader.ts
@@ -489,11 +489,14 @@ export class HydrationDataLoader {
           const blockedBy = blockedByMap.has(key as string);
           const muted = muteMap.has(key as string);
 
+          // IMPORTANT: following, followedBy, and blocking must be string URIs or undefined
+          // (not null) to pass AT Protocol validation. When no relationship exists,
+          // use undefined instead of null.
           return {
-            following: followingUri || null,
-            followingUri: followingUri || null,
-            followedBy: followedByUri || null,
-            blocking: blockingUri || null,
+            following: followingUri || undefined,
+            followingUri: followingUri || undefined,
+            followedBy: followedByUri || undefined,
+            blocking: blockingUri || undefined,
             blockedBy,
             muted
           };

--- a/server/services/xrpc-api.ts
+++ b/server/services/xrpc-api.ts
@@ -684,8 +684,8 @@ export class XRPCApi {
   }
 
   private transformBlobToCdnUrl(blobCid: string, userDid: string, format: 'avatar' | 'banner' | 'feed_thumbnail' | 'feed_fullsize' = 'feed_fullsize', req?: Request): string | undefined {
-    // Check for falsy values, empty strings, and the literal string "undefined"
-    if (!blobCid || blobCid === 'undefined' || blobCid.trim() === '') return undefined;
+    // Check for falsy values, empty strings, and the literal string "undefined" or "null"
+    if (!blobCid || blobCid === 'undefined' || blobCid === 'null' || blobCid.trim() === '') return undefined;
     
     // Use local image proxy to fetch from Bluesky CDN
     const baseUrl = this.getBaseUrl(req);


### PR DESCRIPTION
Fix post hydration and notification display by correcting AT Protocol validation errors for `viewer` state fields and avatar URIs.

The client was encountering `e.ValidationError` for `Output/feed/0/post/author/viewer/blocking` (expected string, received null) and `Output/notifications/20/author/avatar` (expected URI, received invalid string). This PR ensures that `blocking`, `following`, and `followedBy` are `undefined` when no relationship exists, and correctly handles `avatarUrl` values of `"null"` to produce valid URIs.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc18e90e-9224-41e7-bc3e-b7c137495019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc18e90e-9224-41e7-bc3e-b7c137495019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

