### PR TITLE
Fix invalid avatar uri in feed and notifications

### DIFF
--- a/server/services/hydration/embed-resolver.ts
+++ b/server/services/hydration/embed-resolver.ts
@@ -197,8 +197,8 @@ export class EmbedResolver {
           } else {
             avatarUri = this.directCidToCdnUrl(author.avatarUrl, author.did, 'avatar');
           }
-          // Only include avatar field if we got a valid URI
-          if (avatarUri) {
+          // Only include avatar field if we got a valid non-empty string URI
+          if (avatarUri && typeof avatarUri === 'string' && avatarUri.trim() !== '') {
             authorView.avatar = avatarUri;
           }
         }

--- a/server/services/views.ts
+++ b/server/services/views.ts
@@ -130,7 +130,7 @@ export class Views {
         handle: authorProfile.handle,
         displayName: displayName,
         pronouns: authorProfile.pronouns,
-        ...(avatarUrl && { avatar: avatarUrl }),
+        ...(avatarUrl && typeof avatarUrl === 'string' && avatarUrl.trim() !== '' && { avatar: avatarUrl }),
         associated: {
           $type: 'app.bsky.actor.defs#profileAssociated',
           lists: 0,
@@ -183,7 +183,7 @@ export class Views {
         handle: reposterProfile.handle,
         displayName: displayName,
         pronouns: reposterProfile.pronouns,
-        ...(avatarUrl && { avatar: avatarUrl }),
+        ...(avatarUrl && typeof avatarUrl === 'string' && avatarUrl.trim() !== '' && { avatar: avatarUrl }),
         associated: {
           $type: 'app.bsky.actor.defs#profileAssociated',
           lists: 0,


### PR DESCRIPTION
Validate and filter out invalid avatar URIs in API responses to fix client-side validation errors.

Client-side validation failed when avatar fields in feed and notification responses contained empty strings or non-URI values, leading to empty likes and notifications tabs. This PR adds explicit checks to ensure avatar URLs are valid, non-empty strings before being included in the response.

---
<a href="https://cursor.com/background-agent?bcId=bc-6150ec68-dcfd-4c55-9807-35c6d8e8f222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6150ec68-dcfd-4c55-9807-35c6d8e8f222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

