### PR TITLE
Fix build errors after modularization

### DIFF
--- a/server/services/xrpc/services/actor-service.ts
+++ b/server/services/xrpc/services/actor-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';

--- a/server/services/xrpc/services/bookmark-service.ts
+++ b/server/services/xrpc/services/bookmark-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid, getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { serializePostsEnhanced } from '../utils/serializers';

--- a/server/services/xrpc/services/feed-generator-service.ts
+++ b/server/services/xrpc/services/feed-generator-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';
 import { transformBlobToCdnUrl } from '../utils/serializers';

--- a/server/services/xrpc/services/graph-service.ts
+++ b/server/services/xrpc/services/graph-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid, getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';

--- a/server/services/xrpc/services/list-service.ts
+++ b/server/services/xrpc/services/list-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid, getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';

--- a/server/services/xrpc/services/moderation-service.ts
+++ b/server/services/xrpc/services/moderation-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid, getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';

--- a/server/services/xrpc/services/notification-service.ts
+++ b/server/services/xrpc/services/notification-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { transformBlobToCdnUrl } from '../utils/serializers';

--- a/server/services/xrpc/services/post-interaction-service.ts
+++ b/server/services/xrpc/services/post-interaction-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { handleError } from '../utils/error-handler';
 import { maybeAvatar } from '../utils/serializers';
 import { getAuthenticatedDid } from '../utils/auth-helpers';

--- a/server/services/xrpc/services/push-notification-service.ts
+++ b/server/services/xrpc/services/push-notification-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { registerPushSchema, unregisterPushSchema } from '../schemas';

--- a/server/services/xrpc/services/search-service.ts
+++ b/server/services/xrpc/services/search-service.ts
@@ -4,16 +4,16 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { searchService } from '../../search';
 import { getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { maybeAvatar, serializePostsEnhanced } from '../utils/serializers';
 import {
-  searchPostsSchema,
   searchActorsSchema,
   searchActorsTypeaheadSchema,
 } from '../schemas/actor-schemas';
+import { searchPostsSchema } from '../schemas/search-schemas';
 import { searchStarterPacksSchema } from '../schemas/starter-pack-schemas';
 import type { PostModel, PostView, UserModel } from '../types';
 

--- a/server/services/xrpc/services/starter-pack-service.ts
+++ b/server/services/xrpc/services/starter-pack-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';
 import { transformBlobToCdnUrl } from '../utils/serializers';

--- a/server/services/xrpc/services/timeline-service.ts
+++ b/server/services/xrpc/services/timeline-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid, getAuthenticatedDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { resolveActor } from '../utils/resolvers';

--- a/server/services/xrpc/services/unspecced-service.ts
+++ b/server/services/xrpc/services/unspecced-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { handleError } from '../utils/error-handler';
 import { maybeAvatar } from '../utils/serializers';
 import { z } from 'zod';

--- a/server/services/xrpc/services/utility-service.ts
+++ b/server/services/xrpc/services/utility-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
+import { storage } from '../../../storage';
 import { requireAuthDid } from '../utils/auth-helpers';
 import { handleError } from '../utils/error-handler';
 import { transformBlobToCdnUrl } from '../utils/serializers';

--- a/server/services/xrpc/utils/auth-helpers.ts
+++ b/server/services/xrpc/utils/auth-helpers.ts
@@ -4,8 +4,8 @@
  */
 
 import type { Request, Response } from 'express';
-import { storage } from '../../storage';
-import { authService, validateAndRefreshSession } from '../auth';
+import { storage } from '../../../storage';
+import { authService, validateAndRefreshSession } from '../../auth';
 
 /**
  * Get user session for PDS communication by DID

--- a/server/services/xrpc/utils/resolvers.ts
+++ b/server/services/xrpc/utils/resolvers.ts
@@ -4,8 +4,8 @@
  */
 
 import type { Response } from 'express';
-import { storage } from '../../storage';
-import { isUrlSafeToFetch } from '../../utils/security';
+import { storage } from '../../../storage';
+import { isUrlSafeToFetch } from '../../../utils/security';
 import { cacheManager } from './cache';
 
 /**

--- a/server/services/xrpc/utils/serializers.ts
+++ b/server/services/xrpc/utils/serializers.ts
@@ -4,9 +4,9 @@
  */
 
 import type { Request } from 'express';
-import { optimizedHydrator } from '../hydration/index';
-import { dataLoaderHydrator } from '../hydration/dataloader-hydrator';
-import { getRequestDataLoader } from '../../middleware/dataloader';
+import { optimizedHydrator } from '../../hydration/index';
+import { dataLoaderHydrator } from '../../hydration/dataloader-hydrator';
+import { getRequestDataLoader } from '../../../middleware/dataloader';
 
 /**
  * Get the base URL from the request

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -110,7 +110,7 @@ import {
   type InsertGenericRecord,
 } from '@shared/schema';
 import { db, type DbConnection } from './db';
-import { eq, desc, and, or, sql, inArray, isNull } from 'drizzle-orm';
+import { eq, desc, and, or, sql, inArray, isNull, type SQL } from 'drizzle-orm';
 import { encryptionService } from './services/encryption';
 import { sanitizeObject } from './utils/sanitize';
 import { cacheService } from './services/cache';
@@ -1064,7 +1064,6 @@ export class DatabaseStorage implements IStorage {
     feedType?: string
   ): Promise<{ items: FeedItem[]; cursor?: string }> {
     // Build all conditions to apply them together with AND
-    import type { SQL } from 'drizzle-orm';
     const conditions: SQL[] = [eq(feedItems.originatorDid, actorDid)];
 
     // Apply feed type filtering
@@ -3309,7 +3308,6 @@ export class DatabaseStorage implements IStorage {
     limit = 50,
     cursor?: string
   ): Promise<{ starterPacks: StarterPack[]; cursor?: string }> {
-    import type { SQL } from 'drizzle-orm';
     const conditions: SQL[] = [];
     if (cursor) {
       conditions.push(sql`${starterPacks.indexedAt} < ${new Date(cursor)}`);
@@ -3333,7 +3331,6 @@ export class DatabaseStorage implements IStorage {
     limit = 50,
     cursor?: string
   ): Promise<{ starterPacks: StarterPack[]; cursor?: string }> {
-    import type { SQL } from 'drizzle-orm';
     const conditions: SQL[] = [eq(starterPacks.creatorDid, creatorDid)];
     if (cursor) {
       conditions.push(sql`${starterPacks.indexedAt} < ${new Date(cursor)}`);
@@ -3357,7 +3354,6 @@ export class DatabaseStorage implements IStorage {
     limit = 25,
     cursor?: string
   ): Promise<{ starterPacks: StarterPack[]; cursor?: string }> {
-    import type { SQL } from 'drizzle-orm';
     const conditions: SQL[] = [
       sql`${starterPacks.name} ILIKE ${'%' + q + '%'}`,
     ];


### PR DESCRIPTION
Corrects build errors by adjusting `import type` declarations and fixing relative import paths in `server/services/xrpc/` after modularization.

The modularization introduced two main issues: `esbuild` failing on `import type` statements within function bodies, and many relative import paths becoming incorrect due to changes in directory structure. This PR addresses these by hoisting `import type` and adjusting all affected relative paths to ensure modules are correctly resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eab3225-2020-448b-ad9a-f0fea4254b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eab3225-2020-448b-ad9a-f0fea4254b1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

