### PR TITLE
Fix getProfiles and getProfile errors

### DIFF
--- a/server/services/xrpc/services/actor-service.ts
+++ b/server/services/xrpc/services/actor-service.ts
@@ -16,7 +16,7 @@ import {
   getSuggestedFollowsByActorSchema,
   suggestedUsersUnspeccedSchema,
 } from '../schemas';
-import { getProfiles } from "../utils/profile-builder";
+import { getProfiles as buildProfiles } from "../utils/profile-builder";
 import { onDemandBackfill } from '../../on-demand-backfill';
 
 /**
@@ -28,7 +28,7 @@ export async function getProfile(req: Request, res: Response): Promise<void> {
     const params = getProfileSchema.parse(req.query);
 
     // Use legacy API's _getProfiles helper for complex profile serialization
-    const profiles = await getProfiles([params.actor], req);
+    const profiles = await buildProfiles([params.actor], req);
 
     if (profiles.length === 0) {
       // Profile not found - trigger on-demand backfill from their PDS
@@ -76,7 +76,7 @@ export async function getProfiles(req: Request, res: Response): Promise<void> {
     const params = getProfilesSchema.parse(req.query);
 
     // Use legacy API's _getProfiles helper for complex profile serialization
-    const profiles = await getProfiles(params.actors, req);
+    const profiles = await buildProfiles(params.actors, req);
 
     res.json({ profiles });
   } catch (error) {
@@ -108,7 +108,7 @@ export async function getSuggestions(
     const userDids = users.map((u) => u.did);
 
     // Use the full _getProfiles helper to build complete profileView objects
-    const actors = await getProfiles(userDids, req);
+    const actors = await buildProfiles(userDids, req);
 
     // Build response with optional cursor and recId
     const response: {
@@ -161,7 +161,7 @@ export async function getSuggestedFollowsByActor(
 
     // Build full profileView objects using _getProfiles helper
     const suggestionDids = suggestions.map((u) => u.did);
-    const profiles = await getProfiles(suggestionDids, req);
+    const profiles = await buildProfiles(suggestionDids, req);
 
     // Generate recId for recommendation tracking (snowflake-like ID)
     // Using timestamp + random component for uniqueness
@@ -201,7 +201,7 @@ export async function getSuggestedUsersUnspecced(
     const userDids = users.map((u) => u.did);
 
     // Use the full _getProfiles helper to build complete profileView objects
-    const actors = await getProfiles(userDids, req);
+    const actors = await buildProfiles(userDids, req);
 
     res.json({ actors });
   } catch (error) {


### PR DESCRIPTION
Rename imported `getProfiles` to `buildProfiles` in `actor-service.ts` to fix a `TypeError` caused by a naming conflict.

The `actor-service.ts` file had both an imported utility function `getProfiles` and a locally defined handler function `getProfiles`. This caused the local handler to shadow the imported utility, leading to recursive calls with mismatched parameters. Specifically, `getProfile` was calling the handler with `([params.actor], req)` instead of the utility, resulting in `req` being treated as an array and `res` as a request object, triggering `TypeError: Cannot read properties of undefined (reading 'actors[]')` and `TypeError: res.status is not a function`. Renaming the imported function resolves this shadowing issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-f82b325c-4faf-4ea4-bad2-7dace564e7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f82b325c-4faf-4ea4-bad2-7dace564e7c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

