### PR TITLE
Fix install scripts to use base58 command consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd aurora-prism
 ```
 
 The installer will:
-- ✅ Check dependencies (openssl, jq, xxd, bs58)
+- ✅ Check dependencies (openssl, jq, xxd, base58)
 - ✅ Prompt for your domain and configuration preferences
 - ✅ Generate OAuth keys and AppView signing keys
 - ✅ Create secure `.env` configuration

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 # This script handles all setup: key generation, DID configuration, and Docker deployment
 #
 # Prerequisites: Docker, Docker Compose, and DNS configured
-# Dependencies: openssl, jq, xxd, bs58
+# Dependencies: openssl, jq, xxd, base58
 
 set -e
 
@@ -26,7 +26,7 @@ echo ""
 # --- Dependency Check ---
 echo -e "${BLUE}[1/6] Checking dependencies...${NC}"
 MISSING_DEPS=()
-for cmd in docker docker-compose openssl jq xxd bs58; do
+for cmd in docker docker-compose openssl jq xxd base58; do
   if ! command -v $cmd &> /dev/null; then
     MISSING_DEPS+=("$cmd")
   fi
@@ -36,7 +36,7 @@ if [ ${#MISSING_DEPS[@]} -ne 0 ]; then
   echo -e "${RED}❌ Missing required dependencies: ${MISSING_DEPS[*]}${NC}"
   echo ""
   echo "Install missing dependencies:"
-  echo "  Ubuntu/Debian: sudo apt-get install openssl jq xxd python3-pip && pip3 install base58"
+  echo "  Ubuntu/Debian: sudo apt-get install openssl jq xxd python3-base58"
   echo "  macOS: brew install openssl jq xxd && pip3 install base58"
   echo ""
   exit 1
@@ -157,7 +157,7 @@ openssl ecparam -name secp256k1 -genkey -noout -out appview-private.pem
 # Extract public key for DID document
 RAW_PUBKEY=$(openssl ec -in appview-private.pem -pubout -outform DER 2>/dev/null | tail -c 65)
 PREFIXED_KEY=$(printf '\xe7\x01' && echo -n "$RAW_PUBKEY")
-PUBLIC_KEY_MULTIBASE=$(echo -n "$PREFIXED_KEY" | bs58)
+PUBLIC_KEY_MULTIBASE=$(echo -n "$PREFIXED_KEY" | base58)
 
 # Extract components for JWK
 KEY_COMPONENTS_HEX=$(openssl ec -in appview-private.pem -text -noout 2>/dev/null)

--- a/setup-did-and-keys.sh
+++ b/setup-did-and-keys.sh
@@ -3,7 +3,7 @@
 # A pure Bash script to generate AT Protocol compatible secp256k1 keys.
 # No Node.js, no npm, no bullshit.
 #
-# Dependencies: openssl, jq, xxd, bs58
+# Dependencies: openssl, jq, xxd, base58
 
 set -e
 
@@ -12,7 +12,7 @@ echo "========================================"
 echo ""
 
 # --- Dependency Check ---
-for cmd in openssl jq xxd bs58; do
+for cmd in openssl jq xxd base58; do
   if ! command -v $cmd &> /dev/null; then
     echo "❌ Missing required dependency: $cmd"
     echo "Please install it and try again."
@@ -46,7 +46,7 @@ RAW_PUBKEY=$(openssl ec -in appview-private.pem -pubout -outform DER | tail -c 6
 PREFIXED_KEY=$(printf '\xe7\x01' && echo -n "$RAW_PUBKEY")
 
 # 4. Encode the result with Base58BTC to create the final multibase string
-PUBLIC_KEY_MULTIBASE=$(echo -n "$PREFIXED_KEY" | bs58)
+PUBLIC_KEY_MULTIBASE=$(echo -n "$PREFIXED_KEY" | base58)
 
 # --- Private Key Formatting for JWK ---
 echo "⚙️  Formatting private key for application use (JWK)..."


### PR DESCRIPTION
## Summary

- Fixed install scripts to consistently use `base58` command instead of `bs58`
- Updated dependency installation instructions for Ubuntu/Debian to use `python3-base58`
- Corrected mismatch between documented package and actual command name

## Problem

The install scripts referenced the `bs58` command but instructed users to install the Python `base58` package. This mismatch occurred because the original author had the Rust `bs58-cli` crate installed separately, masking the issue.

The Python `base58` package provides a `base58` command, not `bs58`.

## Changes

- `install.sh`: Updated dependency check and command invocation to use `base58`
- `setup-did-and-keys.sh`: Updated dependency check and command invocation to use `base58`
- `README.md`: Updated documentation to reference `base58`

## Test Plan

Both installation methods now provide the same `base58` command:
- Ubuntu/Debian: `sudo apt-get install python3-base58` → provides `base58` command
- macOS: `pip3 install base58` → provides `base58` command

Scripts validated with `bash -n` syntax check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)